### PR TITLE
refractor(core): Own cache system

### DIFF
--- a/utilities.py
+++ b/utilities.py
@@ -998,6 +998,8 @@ class BotBase(AutoShardedBot):
             ApplicationCommandIsGuildOnly,
         )
 
+        self._state: ConnectionState = self._connection
+
     @property
     def avatar_url(self) -> str:
         """
@@ -1182,7 +1184,9 @@ class BotBase(AutoShardedBot):
         try:
             self.logger.warning(f"Member: {member_id} was not found in the cache. Sending HTTP Request.")
 
-            member: Optional[Member] = await guild.fetch_member(member_id)
+            data = await self._connection.http.get_member(guild.id, member_id)
+            member: Member = Member(data=data, guild=guild, state=self._state)
+
             return member
         except (
             nextcord_errors.Forbidden,


### PR DESCRIPTION
## Summary
- Currently, the bot is based on a custom nextcord cache system. This does not give any control over the objects that are assigned to the cache, and objects that are no longer needed are not removed.
- Im planning to write my own cache wrapper, and delete, for example, Guild when the bot leaves some server. This will give us more control over the data and the ConnectionState itself.

## Changed code
- [x] PR interferes with the code of the `main` section.
- [ ] PR interferes with the code of the `Commands` section.
- [ ] PR interferes with the code of the `Events` section.
- [ ] Pull request requires changes to tables in the database.

## Tests
- [ ] I have tested my changes.
- [ ] I have run `pyright` and fixed the relevant issues.
